### PR TITLE
Add -I <Interval>, Remove of -o <offset>, and Refactor -n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 .coverage*
 .idea
 .python-version
+/main.py


### PR DESCRIPTION
Based on [this issue](https://github.com/scdl-org/scdl/issues/519).

The Interval option allows to download a subset of a Playlist or all User options.
It is compatible with all other options including --download-archive, --sync, and -n.

It can be used like this:
`scdl -l https://soundcloud.com/one-thousand-and-one/sets/playlist1 -Interval [10,36]`
`scdl -l https://soundcloud.com/one-thousand-and-one/sets/playlist1 -Interval [,36]`
`scdl -l https://soundcloud.com/one-thousand-and-one/sets/playlist1 -Interval [10,]`

The interval bounds are inclusive.
Indexing starts from 1.
The option supports left- and right-unbounded intervals.
Since a right-unbounded interval equals a skip function, the offset option can be safely removed.

The original recency sorting -n  has been refactored to just -n to avoid clashing track limits.

Some tests are currently broken.

The format could potentially be changed to allow for faster typing on the console.

