### PR TITLE
optimize playlist track fetching + og file downloading

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -778,6 +778,7 @@ def download_playlist(
                 sorted(playlist.tracks, key=lambda track: track.id, reverse=True)[: int(n)],
             )
             kwargs["playlist_offset"] = 0
+
         s = kwargs.get("sync")
         if s:
             if os.path.isfile(s):
@@ -787,8 +788,48 @@ def download_playlist(
                 sys.exit(1)
 
         tracknumber_digits = len(str(len(playlist.tracks)))
+
+        # soundcloud api only returns info for the first 5
+        # & ids on the rest, so we need to fetch the rest
+        tracks = []
+        ids = []
+        for _, track in itertools.islice(enumerate(playlist.tracks, 0), 5):
+            tracks.append(track)
+
+        for _, track in enumerate(playlist.tracks, 5):
+            ids.append(track.id)
+
+        # the endpoint for bulk fetching tracks has a max of 50,
+        # so we need to chunk the ids array into groups of 50
+        if len(ids) > 0:
+            chunk_size = 50
+            for i in range(0, len(ids), chunk_size):
+                tmp_ids = ids[i:i + chunk_size]
+                if playlist.secret_token:
+                    tracks = client.get_tracks(tmp_ids, playlist.id, playlist.secret_token)
+                else:
+                    tracks = client.get_tracks(tmp_ids)
+
+                # get_tracks returns tracks out of order, so we need
+                # to sort them in the same order as the ids array
+                tracks = sorted(
+                    tracks,
+                    key=lambda track: ids.index(track.id)
+                )
+
+                tracks.extend(tracks)
+
+        # current implementation seems to be doubling every track
+        # inside the playlist?? need to investigate, this is just a workaround
+        _tracks = []
+        for track in tracks:
+            if any(track.id == _track.id for _track in _tracks):
+                continue
+
+            _tracks.append(track)
+
         for counter, track in itertools.islice(
-            enumerate(playlist.tracks, 1),
+            enumerate(_tracks, 1),
             kwargs.get("playlist_offset", 0),
             None,
         ):
@@ -796,11 +837,7 @@ def download_playlist(
             logger.info(f"Track n°{counter}")
             playlist_info["tracknumber_int"] = counter
             playlist_info["tracknumber"] = str(counter).zfill(tracknumber_digits)
-            if isinstance(track, MiniTrack):
-                if playlist.secret_token:
-                    track = client.get_tracks([track.id], playlist.id, playlist.secret_token)[0]
-                else:
-                    track = client.get_track(track.id)  # type: ignore[assignment]
+
             assert isinstance(track, BasicTrack)
             download_track(
                 client,
@@ -885,6 +922,10 @@ def download_original_file(
 ) -> Tuple[Optional[str], bool]:
     logger.info("Downloading the original file.")
     to_stdout = is_downloading_to_stdout(kwargs)
+
+    if not track.downloadable:
+        logger.error("Track has downloads disabled")
+        return None, False
 
     # Get the requests stream
     url = client.get_track_original_download(track.id, track.secret_token)


### PR DESCRIPTION
currently with playlists, each track is fetched 1 by 1 when iterating through. this can be improved by fetching the tracks using the [`get_tracks`](https://github.com/7x11x13/soundcloud.py/blob/87b50b3344f9a32193cd4996aa7e2c423894689c/soundcloud/soundcloud.py#L289) function. the api endpoint it calls has a limit of 50 (i believe)
one minor issue i ran into is that my current implementation seems to double the tracks? which is why i'm just making it a draft atm, but i've included a [temporary workaround in the meantime](https://github.com/aprilsbloom/scdl/blob/c19737fc716f5620b8962d051ec0e9934bdfa8d6/scdl/scdl.py#L822-L829)

one more thing, when fetching the original file for a track, each track returns the [`downloadable`](https://github.com/7x11x13/soundcloud.py/blob/87b50b3344f9a32193cd4996aa7e2c423894689c/soundcloud/resource/track.py#L52) attribute. in the [`download_original_file`](https://github.com/scdl-org/scdl/blob/a433ac475fd1c45479466160b436b08aee779e21/scdl/scdl.py#L879) function, we aren't checking for that for some reason, and instead calling the endpoint to fetch the url regardless of if they have downloads enabled or not.